### PR TITLE
IMAP compatibility with Windows 10 WindowsMail

### DIFF
--- a/backend/imap/imap.php
+++ b/backend/imap/imap.php
@@ -2550,14 +2550,14 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
     private function setFromHeaderValue(&$headers) {
         $from = getDefaultFromValue($this->username, $this->domain);
 
-        if (isset($headers["from"])) {
+        if (isset($headers["from"]) && strlen($headers["from"]) > 0) {
             ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->getFromHeaderValue(): from defined: %s", $headers["from"]));
             if (strlen(IMAP_DEFAULTFROM) > 0) {
                 ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->getFromHeaderValue(): Overwriting From: %s", $from));
                 $headers["from"] = $from;
             }
         }
-        elseif (isset($headers["From"])) {
+        elseif (isset($headers["From"]) && strlen($headers["From"]) > 0) {
             ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->getFromHeaderValue(): From defined: %s", $headers["From"]));
             if (strlen(IMAP_DEFAULTFROM) > 0) {
                 ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->getFromHeaderValue(): Overwriting From: %s", $from));


### PR DESCRIPTION
While sending an email with WindowsMail on Windows 10 via the IMAP backend the "From" header delivered by the MUA appears to be empty and therefore the send fails.

28/03/2016 20:21:13 [ 4558] [WBXML] [dirk] [XXXXXXXXXXXXXXXX] I MIME-Version: 1.0
To: Dirk Dietrich dirk@homedietrich.de
From:
Subject: XYZ
Date: Mon, 28 Mar 2016 20:21:13 +0200
Importance: normal

For me the below fix in backend/imap/imap.php (around line 2552) on the from header-check helped that it falls back to the default "from" address.
